### PR TITLE
Updating error handling in webhooks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -97,7 +97,7 @@
       "location" : "ssh://git@github.com/mike-douglas/shipkit-types.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e4c6d270006a2bfbd4186d9c16b7f1accd1d4c5a"
+        "revision" : "a761706fcead1628821f864590acadf6dd5e3a63"
       }
     },
     {
@@ -133,7 +133,7 @@
       "location" : "ssh://git@github.com/mike-douglas/swift-aftership.git",
       "state" : {
         "branch" : "main",
-        "revision" : "6283a0bf062e47665694852155b6faa25976a7d4"
+        "revision" : "8671642c2bcc7111242785bc5d99a992f36171fd"
       }
     },
     {


### PR DESCRIPTION
1. Mail webhook no longer returns a 404 when the user is not found. There are a lot of false positives showing up in metrics with this case.
2. AfterShip webhook does the same. Both return an .accepted response unless serious errors occur.
3. Handling the case where an existing package is trying to be tracked. If the user matches the userId customField we return the package (and don't return an error)